### PR TITLE
__pairs/__ipairs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PKG_CONFIG=pkg-config
 LUA=lua
 
-LUA_CFLAGS=`$(PKG_CONFIG) --cflags lua5.1 2>/dev/null || $(PKG_CONFIG) --cflags lua`
+LUA_CFLAGS=`$(PKG_CONFIG) --cflags lua5.2 2>/dev/null || $(PKG_CONFIG) --cflags lua`
 SOCFLAGS=-fPIC
 SOCC=$(CC) -shared $(SOCFLAGS)
 CFLAGS=-fPIC -g -Wall -Werror $(LUA_CFLAGS) -fvisibility=hidden -Wno-unused-function --std=gnu99

--- a/ffi.c
+++ b/ffi.c
@@ -1924,6 +1924,40 @@ static int cdata_len(lua_State* L)
     return luaL_error(L, "type %s does not implement the __len metamethod", lua_tostring(L, -1));
 }
 
+static int cdata_pairs(lua_State* L)
+{
+    struct ctype ct;
+    int ret;
+
+    lua_settop(L, 1);
+    to_cdata(L, 1, &ct);
+
+    ret = call_user_op(L, "__pairs", 1, 2, &ct);
+    if (ret >= 0) {
+        return ret;
+    }
+
+    push_type_name(L, 2, &ct);
+    return luaL_error(L, "type %s does not implement the __pairs metamethod", lua_tostring(L, -1));
+}
+
+static int cdata_ipairs(lua_State* L)
+{
+    struct ctype ct;
+    int ret;
+
+    lua_settop(L, 1);
+    to_cdata(L, 1, &ct);
+
+    ret = call_user_op(L, "__ipairs", 1, 2, &ct);
+    if (ret >= 0) {
+        return ret;
+    }
+
+    push_type_name(L, 2, &ct);
+    return luaL_error(L, "type %s does not implement the __ipairs metamethod", lua_tostring(L, -1));
+}
+
 static int cdata_add(lua_State* L)
 {
     struct ctype lt, rt, ct;
@@ -2846,6 +2880,8 @@ static const luaL_Reg cdata_mt[] = {
     {"__tostring", &cdata_tostring},
     {"__concat", &cdata_concat},
     {"__len", &cdata_len},
+    {"__pairs", &cdata_pairs},
+    {"__ipairs", &cdata_ipairs},
     {NULL, NULL}
 };
 

--- a/test.lua
+++ b/test.lua
@@ -844,5 +844,15 @@ local tp = ffi.metatype("struct newtest", {__new =
 local v = tp(1, 2, 3)
 assert(v.a == 1 and v.b == 2 and v.c == 3)
 
+-- tests for __pairs and __ipairs; not iterating just testing what is returned
+local tp = ffi.metatype("struct newtest",
+  {__pairs = function(tp) return tp.a, tp.b end, __ipairs = function(tp) return tp.b, tp.c end}
+)
+local v = tp(1, 2, 3)
+x, y = pairs(v)
+assert(x == 1 and y == 2)
+x, y = ipairs(v)
+assert(x == 2 and y == 3)
+
 print('Test PASSED')
 


### PR DESCRIPTION
Add __pairs and __ipairs support. Bump default Lua version to 5.2 not 5.1. LuaJIT supports __pairs and __ipairs on cdata even though it is "5.1", so for luaffi defaulting to 5.2 makes sense (also for other metatable improvements).
