### PR TITLE
Pointers

### DIFF
--- a/ffi.c
+++ b/ffi.c
@@ -1407,7 +1407,7 @@ static int ffi_metatype(lua_State* L)
  * the stack, otherwise it returns 0 and pushes nothing */
 int push_user_mt(lua_State* L, int ct_usr, const struct ctype* ct)
 {
-    if (ct->pointers || (ct->type != STRUCT_TYPE && ct->type != UNION_TYPE)) {
+    if (ct->type != STRUCT_TYPE && ct->type != UNION_TYPE) {
         return 0;
     }
 
@@ -1816,6 +1816,7 @@ static int call_user_op(lua_State* L, const char* opfield, int idx, int ct_usr, 
             lua_call(L, 1, LUA_MULTRET);
             return lua_gettop(L) - top + 1;
         }
+      lua_pop(L, 2);
     }
     return -1;
 }

--- a/test.lua
+++ b/test.lua
@@ -854,5 +854,18 @@ assert(x == 1 and y == 2)
 x, y = ipairs(v)
 assert(x == 2 and y == 3)
 
+-- test for pointer to struct having same metamethods
+local st = ffi.cdef "struct ptest {int a, b;};"
+local tp = ffi.metatype("struct ptest", {__index = function(s, k) return k end, __len = function(s) return 3 end})
+
+local a = tp(1, 2)
+assert(a.banana == "banana")
+assert(#a == 3)
+local b = ffi.new("int[2]")
+local c = ffi.cast("struct ptest *", b)
+assert(c.banana == "banana") -- should have same methods
+assert(#c == 3)
+
+
 print('Test PASSED')
 


### PR DESCRIPTION
LuaJIT calls ffi metatypes for pointers to structs and unions as well as plain structs and unions.

Also while I was adding this I found that call_user_op does not pop correctly in a failure case which this triggered.
