### PR TITLE
Tweaked syntax to avoid compilation error

### DIFF
--- a/dynasm/dasm_x86.h
+++ b/dynasm/dasm_x86.h
@@ -204,7 +204,7 @@ void dasm_put(Dst_DECL, int start, ...)
       case DASM_SPACE: p++; ofs += n; break;
       case DASM_SETLABEL: b[pos-2] = -0x40000000; break;  /* Neg. label ofs. */
       case DASM_VREG: CK((n&-8) == 0 && (n != 4 || (*p&1) == 0), RANGE_VREG);
-	if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;
+	if (*p++ == 1 && *p == DASM_DISP) {mrm = n;} continue;
       }
       mrm = 4;
     } else {


### PR DESCRIPTION
This little fix prevents a compilation error under GNU/Linux systems which says:

```
In file included from call.c:38:0:
dynasm/dasm_x86.h: In function ‘dasm_put’:
dynasm/dasm_x86.h:207:2: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
  if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;
```

Copying the syntax of other lines of code, the problem seems to be fixed. Found in an Arch Linux machine using Lua 5.3.3.


